### PR TITLE
Linux compatibility

### DIFF
--- a/NC Reactor Planner/Block.cs
+++ b/NC Reactor Planner/Block.cs
@@ -1,7 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Drawing;
-using System.Windows.Media.Media3D;
 
 namespace NC_Reactor_Planner
 {

--- a/NC Reactor Planner/Casing.cs
+++ b/NC Reactor Planner/Casing.cs
@@ -1,7 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Drawing;
-using System.Windows.Media.Media3D;
 
 namespace NC_Reactor_Planner
 {

--- a/NC Reactor Planner/Cooler.cs
+++ b/NC Reactor Planner/Cooler.cs
@@ -4,7 +4,6 @@ using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
 using System.Drawing;
-using System.Windows.Media.Media3D;
 
 namespace NC_Reactor_Planner
 {

--- a/NC Reactor Planner/FuelCell.cs
+++ b/NC Reactor Planner/FuelCell.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Windows.Media.Media3D;
 using System.Drawing;
 
 namespace NC_Reactor_Planner

--- a/NC Reactor Planner/Moderator.cs
+++ b/NC Reactor Planner/Moderator.cs
@@ -1,7 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Drawing;
-using System.Windows.Media.Media3D;
 
 namespace NC_Reactor_Planner
 {

--- a/NC Reactor Planner/NC Reactor Planner.csproj
+++ b/NC Reactor Planner/NC Reactor Planner.csproj
@@ -69,7 +69,6 @@
     <Reference Include="Newtonsoft.Json, Version=11.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
       <HintPath>..\packages\Newtonsoft.Json.11.0.2\lib\net45\Newtonsoft.Json.dll</HintPath>
     </Reference>
-    <Reference Include="PresentationCore" />
     <Reference Include="System" />
     <Reference Include="System.Core" />
     <Reference Include="System.Web.Extensions" />
@@ -113,6 +112,7 @@
     <Compile Include="FuelCell.cs" />
     <Compile Include="Moderator.cs" />
     <Compile Include="Palette.cs" />
+    <Compile Include="Point3D.cs" />
     <Compile Include="Program.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="Properties\Resources.Designer.cs">
@@ -126,7 +126,9 @@
     </Compile>
     <Compile Include="SchematicaExportHelper.cs" />
     <Compile Include="Settings.cs" />
+    <Compile Include="Size3D.cs" />
     <Compile Include="Updater.cs" />
+    <Compile Include="Vector3D.cs" />
     <EmbeddedResource Include="ConfigurationUI.resx">
       <DependentUpon>ConfigurationUI.cs</DependentUpon>
     </EmbeddedResource>

--- a/NC Reactor Planner/Palette.cs
+++ b/NC Reactor Planner/Palette.cs
@@ -63,7 +63,6 @@ namespace NC_Reactor_Planner
                     using (Pen highlightPen = new Pen(Color.Blue, 3))
                         DrawHighlightRectangle(g, Xhighlight, Zhighlight, highlightPen);
 
-                g.CompositingMode = CompositingMode.SourceCopy;
                 g.CompositingQuality = CompositingQuality.HighSpeed;
                 g.InterpolationMode = InterpolationMode.NearestNeighbor;
                 g.SmoothingMode = SmoothingMode.HighSpeed;

--- a/NC Reactor Planner/Palette.cs
+++ b/NC Reactor Planner/Palette.cs
@@ -10,7 +10,6 @@ using System.IO;
 using System.Resources;
 using System.Reflection;
 using System.Windows.Forms;
-using System.Windows.Media.Media3D;
 using NC_Reactor_Planner.Properties;
 
 namespace NC_Reactor_Planner

--- a/NC Reactor Planner/Point3D.cs
+++ b/NC Reactor Planner/Point3D.cs
@@ -1,0 +1,58 @@
+using System;
+
+
+namespace NC_Reactor_Planner
+{
+    public struct Point3D
+        : IEquatable<Point3D>
+    {
+        public static bool operator ==(Point3D left, Point3D right)
+        {
+            return left.X == right.X && left.Y == right.Y && left.Z == right.Z;
+        }
+
+        public static bool operator !=(Point3D left, Point3D right)
+        {
+            return !(left == right);
+        }
+
+        public static Point3D operator +(Point3D left, Vector3D right)
+        {
+            return new Point3D(left.X + right.X, left.Y + right.Y, left.Z + right.Z);
+        }
+
+        public double X { get; set; }
+        
+        public double Y { get; set; }
+        
+        public double Z { get; set; }
+
+        public Point3D(double x, double y, double z)
+        {
+            this.X = x;
+            this.Y = y;
+            this.Z = z;
+        }
+
+        public bool Equals(Point3D other)
+        {
+            return this.X.Equals(other.X) && this.Y.Equals(other.Y) && this.Z.Equals(other.Z);
+        }
+
+        public override bool Equals(object obj)
+        {
+            return obj is Point3D other && Equals(other);
+        }
+
+        public override int GetHashCode()
+        {
+            unchecked
+            {
+                var hashCode = this.X.GetHashCode();
+                hashCode = (hashCode * 397) ^ this.Y.GetHashCode();
+                hashCode = (hashCode * 397) ^ this.Z.GetHashCode();
+                return hashCode;
+            }
+        }
+    }
+}

--- a/NC Reactor Planner/Program.cs
+++ b/NC Reactor Planner/Program.cs
@@ -26,7 +26,7 @@ namespace NC_Reactor_Planner
 
         static void PreStartUp()
         {
-            FileInfo jsonDll = new FileInfo("Newtonsoft.json.dll");
+            FileInfo jsonDll = new FileInfo("Newtonsoft.Json.dll");
             if (!jsonDll.Exists)
             {
                 using (var writer = jsonDll.OpenWrite())

--- a/NC Reactor Planner/Reactor.cs
+++ b/NC Reactor Planner/Reactor.cs
@@ -1,7 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Windows.Media.Media3D;
 using System.Runtime.Serialization.Formatters.Binary;
 using System.Reflection;
 using System.IO;

--- a/NC Reactor Planner/ReactorGridLayer.cs
+++ b/NC Reactor Planner/ReactorGridLayer.cs
@@ -7,7 +7,6 @@ using System.Windows.Forms;
 using System.Drawing;
 using System.Drawing.Drawing2D;
 using System.IO;
-using System.Windows.Media.Media3D;
 
 namespace NC_Reactor_Planner
 {

--- a/NC Reactor Planner/ReactorGridLayer.cs
+++ b/NC Reactor Planner/ReactorGridLayer.cs
@@ -112,7 +112,6 @@ namespace NC_Reactor_Planner
 
         public void FullRedraw(Graphics g, bool forExport = false)
         {
-            g.CompositingMode = CompositingMode.SourceCopy;
             g.CompositingQuality = CompositingQuality.HighSpeed;
             g.InterpolationMode = InterpolationMode.NearestNeighbor;
             g.SmoothingMode = SmoothingMode.HighSpeed;

--- a/NC Reactor Planner/SchematicaExportHelper.cs
+++ b/NC Reactor Planner/SchematicaExportHelper.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Windows.Media.Media3D;
 using System.Text;
 using System.Threading.Tasks;
 using fNbt;

--- a/NC Reactor Planner/Size3D.cs
+++ b/NC Reactor Planner/Size3D.cs
@@ -1,0 +1,18 @@
+namespace NC_Reactor_Planner
+{
+    public struct Size3D
+    {
+        public double X { get; set; }
+        
+        public double Y { get; set; }
+        
+        public double Z { get; set; }
+
+        public Size3D(double x, double y, double z)
+        {
+            this.X = x;
+            this.Y = y;
+            this.Z = z;
+        }
+    }
+}

--- a/NC Reactor Planner/Vector3D.cs
+++ b/NC Reactor Planner/Vector3D.cs
@@ -1,0 +1,23 @@
+namespace NC_Reactor_Planner
+{
+    public struct Vector3D
+    {
+        public static Vector3D operator *(Vector3D left, int right)
+        {
+            return new Vector3D(left.X * right, left.Y * right, left.Z * right);
+        }
+        
+        public double X { get; set; }
+        
+        public double Y { get; set; }
+        
+        public double Z { get; set; }
+
+        public Vector3D(double x, double y, double z)
+        {
+            this.X = x;
+            this.Y = y;
+            this.Z = z;
+        }
+    }
+}


### PR DESCRIPTION
I made the code Mono/Linux compatible. See also issue #5 

Three changes were made:
* Removed the dependency on `PresentationCore`. The only dependency on WPF was the use of `Point3D`, `Vector3D` and `Size3D` from `System.Windows.Media.Media3D`. And their functionality is barely even used. I just added those three structs and implemented the minimum required interface so it can run. I would recommend to consider merging them in the future and perhaps also replace `double` to `int`. I couldn't immediately see why `double` would be required. But I also didn't want to spend time on this and the main point of this branch is Linux compatibility.
* Corrected the case of a path string to Newtonsoft.Json. Linux is case-sensitive in regards to paths.
* Hade to remove the `CompositingMode` change as it caused issues on Linux and reverted to the default. It shouldn't change any of the behavior as the bitmaps are opaque anyway.